### PR TITLE
Update SR.jl dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,25 +29,25 @@ jobs:
           - "online"
           - "llamafile"
         julia-version:
-          - "1.10"
+          - "1.11"
           - "1"
         os:
           - ubuntu-latest
         include:
           - os: windows-latest
-            julia-version: "1"
+            julia-version: "~1.11.0-0"
             test: "online"
           - os: macOS-latest
-            julia-version: "1"
+            julia-version: "~1.11.0-0"
             test: "online"
           - os: ubuntu-latest
             julia-version: "~1.11.0-0"
             test: "online"
           - os: windows-latest
-            julia-version: "1"
+            julia-version: "~1.11.0-0"
             test: "llamafile"
           - os: macOS-latest
-            julia-version: "1"
+            julia-version: "~1.11.0-0"
             test: "llamafile"
           - os: ubuntu-latest
             julia-version: "~1.11.0-0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LibraryAugmentedSymbolicRegression"
 uuid = "158930c3-947c-4174-974b-74b39e64a28f"
 authors = ["AtharvaSehgal <atharva.sehgal@gmail.com>", "AryaGrayeli <arya.grayeli@gmail.com>", "MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -59,4 +59,4 @@ UUIDs = "1"
 julia = "1.9 - 1.11"
 
 [sources]
-SymbolicRegression = { url = "git@github.com:MilesCranmer/SymbolicRegression.jl.git", rev="v2.0.0-alpha.6" }
+SymbolicRegression = { url = "https://github.com/MilesCranmer/SymbolicRegression.jl.git", rev="v2.0.0-alpha.6" }

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LibraryAugmentedSymbolicRegression"
 uuid = "158930c3-947c-4174-974b-74b39e64a28f"
 authors = ["AtharvaSehgal <atharva.sehgal@gmail.com>", "AryaGrayeli <arya.grayeli@gmail.com>", "MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.3.2"
+version = "0.3.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -53,7 +53,10 @@ PromptingTools = "0.65 - 0.81"
 Random = "<0.0.1, 1"
 Reexport = "1"
 StatsBase = "0.33, 0.34"
-SymbolicRegression = "^1"
+SymbolicRegression = "2.0"
 TOML = "<0.0.1, 1"
 UUIDs = "1"
 julia = "1.9 - 1.11"
+
+[sources]
+SymbolicRegression = { url = "git@github.com:MilesCranmer/SymbolicRegression.jl.git", rev="v2.0.0-alpha.6" }

--- a/Project.toml
+++ b/Project.toml
@@ -56,7 +56,7 @@ StatsBase = "0.33, 0.34"
 SymbolicRegression = "2.0"
 TOML = "<0.0.1, 1"
 UUIDs = "1"
-julia = "1.9 - 1.11"
+julia = "1.11 - 1.12"
 
 [sources]
 SymbolicRegression = { url = "https://github.com/MilesCranmer/SymbolicRegression.jl.git", rev="v2.0.0-alpha.6" }

--- a/src/LLMFunctions.jl
+++ b/src/LLMFunctions.jl
@@ -13,7 +13,6 @@ using DynamicExpressions:
     get_contents,
     with_contents,
     constructorof,
-    copy_node,
     set_node!,
     count_nodes,
     has_constants,
@@ -22,7 +21,7 @@ using DynamicExpressions:
     AbstractOperatorEnum
 using Compat: Returns, @inline
 using SymbolicRegression:
-    Options, DATA_TYPE, gen_random_tree_fixed_size, random_node_and_parent, AbstractOptions
+    Options, DATA_TYPE, gen_random_tree_fixed_size, crossover_trees, AbstractOptions
 using SymbolicRegression.MutationFunctionsModule: with_contents_for_mutation
 using ..LLMOptionsModule: LaSROptions
 using ..LLMUtilsModule:
@@ -190,39 +189,6 @@ function _gen_llm_random_tree(
     end
 
     return out
-end
-
-"""Crossover between two expressions"""
-function crossover_trees(
-    tree1::AbstractExpressionNode{T}, tree2::AbstractExpressionNode{T}
-)::Tuple{AbstractExpressionNode{T},AbstractExpressionNode{T}} where {T<:DATA_TYPE}
-    tree1 = copy_node(tree1)
-    tree2 = copy_node(tree2)
-
-    node1, parent1, side1 = random_node_and_parent(tree1)
-    node2, parent2, side2 = random_node_and_parent(tree2)
-
-    node1 = copy_node(node1)
-
-    if side1 == 'l'
-        parent1.l = copy_node(node2)
-        # tree1 now contains this.
-    elseif side1 == 'r'
-        parent1.r = copy_node(node2)
-        # tree1 now contains this.
-    else # 'n'
-        # This means that there is no parent2.
-        tree1 = copy_node(node2)
-    end
-
-    if side2 == 'l'
-        parent2.l = node1
-    elseif side2 == 'r'
-        parent2.r = node1
-    else # 'n'
-        tree2 = node1
-    end
-    return tree1, tree2
 end
 
 function concept_evolution(idea_database, options::AbstractOptions)

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -91,11 +91,14 @@ function modelexpr(
             procs::Union{Vector{Int},Nothing} = nothing
             addprocs_function::Union{Function,Nothing} = nothing
             heap_size_hint_in_bytes::Union{Integer,Nothing} = nothing
+            worker_timeout::Union{Real,Nothing} = nothing
             worker_imports::Union{Vector{Symbol},Nothing} = nothing
             logger::Union{AbstractSRLogger,Nothing} = nothing
             runtests::Bool = true
             run_id::Union{String,Nothing} = nothing
             loss_type::Type{L} = Nothing
+            guesses::Union{AbstractVector,AbstractVector{<:AbstractVector},Nothing} =
+                nothing
             selection_method::Function = choose_best
             dimensions_type::Type{D} = SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}
         end)

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -5,7 +5,7 @@ using .SymbolicRegression: @recorder
 
 # It's important that we explicitly import the mutate! function from SymbolicRegression
 # so Julia knows that we're extending it.
-import SymbolicRegression: mutate!, MutationResult
+import SymbolicRegression: mutate!, MutationResult, crossover_trees
 
 using ..LLMOptionsStructModule: LaSROptions
 using ..LLMFunctionsModule: llm_mutate_tree, llm_crossover_trees, llm_randomize_tree

--- a/src/MutationWeights.jl
+++ b/src/MutationWeights.jl
@@ -23,6 +23,7 @@ Base.@kwdef mutable struct LaSRMutationWeights <: AbstractMutationWeights
     # Mutation weights imported from SR.jl
     mutate_constant::Float64 = 0.0353
     mutate_operator::Float64 = 3.63
+    mutate_feature::Float64 = 0.1
     swap_operands::Float64 = 0.00608
     rotate_tree::Float64 = 1.42
     add_node::Float64 = 0.0771

--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -1,44 +1,96 @@
 module ParseModule
 
+using DispatchDoctor: @unstable
 using DynamicExpressions
+using DynamicExpressions.NodeModule: Node
 using SymbolicRegression: AbstractOptions, DATA_TYPE
 
 """
-    parse_expr(expr_str::String, options) -> AbstractExpressionNode
+    parse_expr(expr_str::String, options)
 
 Given a string (e.g., from string_tree) and an options object (containing
 operators, variable naming conventions, etc.), reconstruct an
 AbstractExpressionNode.
 """
-function parse_expr(
+@unstable function parse_expr(
     ::Type{T}, expr_str::String, options::AbstractOptions
-) where {T<:DATA_TYPE}
+)::AbstractExpression{T} where {T<:DATA_TYPE}
+    node_type = options.node_type{T}::Type{<:AbstractExpressionNode{T}}
+    expression_type = options.expression_type{T,node_type}::Type{<:AbstractExpression{T}}
+    ops = options.operators
+    varnames = get_variable_names(options.variable_names)
+    expr_str_norm = _normalize_expr_string(expr_str)
+
+    local ast
     try
-        expr_str = replace(expr_str, r"\*\*" => "^")
-        expr_str = replace(expr_str, r"\*\*" => "^")
-        return parse_expression(
-            Meta.parse(expr_str);
-            operators=options.operators,
-            node_type=options.node_type,
-            expression_type=options.expression_type,
-            variable_names=get_variable_names(options.variable_names),
-        )
-
-        # # If it's an assignment like `a = expr`, just take the RHS
-        # if parsed.head == :(=)
-        #     parsed = parsed.args[2]
-        # end
-
-        # expr = _parse_expr(parsed, options, T)
-        # # ensure that the expression can be rendered
-        # render_expr(expr, options)
-        # return expr
+        ast = Meta.parse(expr_str_norm)
     catch e
-        @info "Failed to parse expression: $expr_str"
-        @info "Error: $e"
-        @info "Returning a constant node with value 1."
-        return _make_constant_node(1, T)
+        if occursin(r"^\s*[^=\n]+=", expr_str_norm)
+            stripped = replace(expr_str_norm, r"^\s*[^=\n]+=\s*" => "")
+            try
+                ast = Meta.parse(stripped)
+            catch
+                @warn "Failed to Meta.parse even after stripping LHS: $expr_str"
+                @warn "Error: $e"
+                @warn "Returning a constant node with value 1."
+                return Expression(
+                    node_type(; val=convert(T, 1.0));
+                    options.operators,
+                    options.variable_names,
+                )
+            end
+        else
+            @warn "Failed to Meta.parse: $expr_str"
+            @warn "Error: $e"
+            @warn "Returning a constant node with value 1."
+            return Expression(
+                node_type(; val=convert(T, 1.0)); options.operators, options.variable_names
+            )
+        end
     end
+
+    ast = _rhs_of_assignment(ast)
+
+    try
+        return parse_expression(
+            ast;
+            operators=ops,
+            node_type=node_type,
+            expression_type=expression_type,
+            variable_names=varnames,
+        )::AbstractExpression{T}
+    catch e
+        @warn "Failed to parse expression: $expr_str"
+        @warn "Normalized: $expr_str_norm"
+        @warn "Error: $e"
+        @warn "Returning a constant node with value 1."
+        return Expression(
+            node_type(; val=convert(T, 1.0)); options.operators, options.variable_names
+        )
+    end
+end
+
+@unstable function _rhs_of_assignment(ast::Expr)
+    if ast isa Expr
+        if ast.head === :(=) && length(ast.args) ≥ 2
+            return ast.args[2]
+        elseif ast.head === :block && !isempty(ast.args)
+            return _rhs_of_assignment(last(ast.args))
+        end
+    end
+    return ast
+end
+
+function _normalize_expr_string(s::AbstractString)
+    # Normalize whitespace
+    s = replace(s, r"\s+" => " ")
+    # Replace standalone C or (C) with 1.0 or (1.0)
+    s = replace(s, r"(?<!\w)C(?!\w)" => "1.0")
+    s = replace(s, r"(?<!\w)\(C\)(?!\w)" => "(1.0)")
+    # TODO: Right now, making all variables lowercase. This might not always be desired.
+    s = lowercase(s)
+    s = replace(s, r"\*\*" => "^")
+    strip(s)
 end
 
 """
@@ -52,6 +104,24 @@ function render_expr(
     ex::AbstractExpression{T}, options::AbstractOptions
 )::String where {T<:DATA_TYPE}
     return render_expr(get_contents(ex), options)
+end
+
+@unstable function _sketch_const(val)
+    does_not_need_brackets = (typeof(val) <: Union{Real,AbstractArray})
+
+    if does_not_need_brackets
+        if isinteger(val) && (abs(val) < 5) # don't abstract integer constants from -4 to 4, useful for exponents
+            string(val)
+        else
+            "C"
+        end
+    else
+        if isinteger(val) && (abs(val) < 5) # don't abstract integer constants from -4 to 4, useful for exponents
+            "(" * string(val) * ")"
+        else
+            "(C)"
+        end
+    end
 end
 
 function render_expr(tree::AbstractExpressionNode{T}, options)::String where {T<:DATA_TYPE}

--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -1,8 +1,6 @@
 module ParseModule
 
-using DispatchDoctor: @unstable
 using DynamicExpressions
-using .DynamicExpressions.NodeModule: Node
 using SymbolicRegression: AbstractOptions, DATA_TYPE
 
 """
@@ -17,164 +15,29 @@ function parse_expr(
 ) where {T<:DATA_TYPE}
     try
         expr_str = replace(expr_str, r"\*\*" => "^")
-        parsed = Meta.parse(expr_str)
+        expr_str = replace(expr_str, r"\*\*" => "^")
+        return parse_expression(
+            Meta.parse(expr_str);
+            operators=options.operators,
+            node_type=options.node_type,
+            expression_type=options.expression_type,
+            variable_names=get_variable_names(options.variable_names),
+        )
 
-        # If it's an assignment like `a = expr`, just take the RHS
-        if parsed.head == :(=)
-            parsed = parsed.args[2]
-        end
+        # # If it's an assignment like `a = expr`, just take the RHS
+        # if parsed.head == :(=)
+        #     parsed = parsed.args[2]
+        # end
 
-        expr = _parse_expr(parsed, options, T)
-        # ensure that the expression can be rendered
-        render_expr(expr, options)
-        return expr
+        # expr = _parse_expr(parsed, options, T)
+        # # ensure that the expression can be rendered
+        # render_expr(expr, options)
+        # return expr
     catch e
         @info "Failed to parse expression: $expr_str"
         @info "Error: $e"
         @info "Returning a constant node with value 1."
         return _make_constant_node(1, T)
-    end
-end
-
-function _make_constant_node(val::Number, ::Type{T}) where {T<:DATA_TYPE}
-    return Node{T}(; val=convert(T, val))
-end
-
-function _make_variable_node(
-    sym::Symbol, options::AbstractOptions, ::Type{T}
-) where {T<:DATA_TYPE}
-    str_sym = string(sym)
-    # if C or C1 or c1, basically capital or lower c followed by number
-    # use regex
-    if occursin(r"^c\d*$", lowercase(str_sym))
-        return Node{T}(; val=convert(T, 1))
-    end
-    # Get the list of variable names from options.
-    var_names = get_variable_names(options.variable_names)
-    idx = findfirst(x -> x == str_sym, var_names)
-    if idx === nothing
-        # Fallback: try to interpret as the previous "x5" format.
-        try
-            idx = parse(Int, str_sym[2:end])
-        catch e
-            error("Unrecognized variable symbol: $sym")
-        end
-    end
-    return Node{T}(; feature=idx)
-end
-
-function _make_call_node(ex::Expr, options::AbstractOptions, ::Type{T}) where {T<:DATA_TYPE}
-    op_sym = ex.args[1]
-    argexprs = ex.args[2:end]
-    children = map(child_ex -> _parse_expr(child_ex, options, T), argexprs)
-    op_idx = _find_operator_index(op_sym, options)
-    if length(children) == 1
-        return Node{T}(; op=op_idx, l=children[1])
-    elseif length(children) == 2
-        return Node{T}(; op=op_idx, l=children[1], r=children[2])
-    elseif length(children) > 2
-        # Reduce an n-ary operator to a binary tree (left-associative)
-        node = Node{T}(; op=op_idx, l=children[1], r=children[2])
-        for child in children[3:end]
-            node = Node{T}(; op=op_idx, l=node, r=child)
-        end
-        return node
-    else
-        error("Operator with $(length(children)) children not supported.")
-    end
-end
-
-function _render_function(
-    fn::F, function_str_map::Dict{S,S}
-)::String where {F<:Function,S<:AbstractString}
-    fn_str = replace(string(fn), "safe_" => "")
-    if haskey(function_str_map, fn_str)
-        return function_str_map[fn_str]
-    end
-    return fn_str
-end
-
-@unstable function _find_operator_index(op_sym, options::AbstractOptions)
-    function_str_map = Dict("pow" => "^")
-    binops = map(
-        x -> lowercase(_render_function(x, function_str_map)), options.operators.binops
-    )
-    unaops = map(
-        x -> lowercase(_render_function(x, function_str_map)), options.operators.unaops
-    )
-
-    op = lowercase(string(op_sym))
-
-    if op == "^"
-        # direct hit
-        if (i = findfirst(==("^"), binops)) !== nothing
-            return UInt8(i)
-        end
-        # fallback: anything that *looks like* pow
-        if (i = findfirst(n -> occursin("pow", n) || occursin("power", n), binops)) !==
-            nothing
-            return UInt8(i)
-        end
-        error("Could not find a power operator in options.operators.binops")
-    end
-
-    if (i = findfirst(==(op), binops)) !== nothing
-        return UInt8(i)
-    end
-    if (i = findfirst(==(op), unaops)) !== nothing
-        return UInt8(i)
-    end
-
-    return error("Unrecognized operator symbol: $(op_sym)")
-end
-function _parse_expr(ex, options::AbstractOptions, ::Type{T}) where {T<:DATA_TYPE}
-    if ex isa Number
-        return _make_constant_node(ex, T)
-    elseif ex isa Symbol
-        return _make_variable_node(ex, options, T)
-    elseif ex isa Expr
-        if ex.head === :call
-            op = ex.args[1]
-            if op === :- && length(ex.args) == 2
-                child = ex.args[2]
-                if child isa Number
-                    return _make_constant_node(-child, T)
-                end
-                # general case: 0 - child (use existing binary "-")
-                minus_idx = _find_operator_index(:-, options)  # must return BINOP index
-                return Node{T}(;
-                    op=minus_idx,
-                    l=_make_constant_node(zero(T), T),
-                    r=_parse_expr(child, options, T),
-                )
-            end
-            if op === :+ && length(ex.args) == 2
-                return _parse_expr(ex.args[2], options, T)  # unary plus is a no-op
-            end
-            return _make_call_node(ex, options, T)
-        else
-            error("Unsupported expression head: $(ex.head)")
-        end
-    else
-        error("Unsupported expression: $(ex)")
-    end
-end
-
-@unstable function _sketch_const(val)
-    does_not_need_brackets = (typeof(val) <: Union{Real,AbstractArray})
-
-    if does_not_need_brackets
-        if isinteger(val) && (abs(val) < 5) # don't abstract integer constants from -4 to 4, useful for exponents
-            string(val)
-        else
-            "C"
-        end
-    else
-        if isinteger(val) && (abs(val) < 5) # don't abstract integer constants from -4 to 4, useful for exponents
-            "(" * string(val) * ")"
-        else
-            "(C)"
-        end
     end
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -21,7 +21,10 @@ TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
 [compat]
 Aqua = "0.8"
-SymbolicRegression = ">=1.7.1"
+SymbolicRegression = "2.0"
 
 [preferences.LibraryAugmentedSymbolicRegression]
 dispatch_doctor_mode = "error"
+
+[sources]
+SymbolicRegression = { url = "https://github.com/MilesCranmer/SymbolicRegression.jl.git", rev="v2.0.0-alpha.6" }

--- a/test/test_lasr_parser.jl
+++ b/test/test_lasr_parser.jl
@@ -2,13 +2,15 @@
 # These are round trip tests to ensure that the parser is working correctly.
 println("Testing LaSR expression parser")
 
+using Revise
 using Random: MersenneTwister
+using DynamicExpressions: parse_expression
 using LibraryAugmentedSymbolicRegression:
     LaSROptions, string_tree, parse_expr, render_expr, gen_random_tree
-include("test_params.jl")
+include("test/test_params.jl")
 
 @inline safepow(x, y) = sign(x) * abs(x)^y
-options = LaSROptions(;
+options = Options(;
     default_params..., binary_operators=[-, +, *, safepow], unary_operators=[sin, cos, exp]
 )
 
@@ -25,10 +27,18 @@ for depth in [5, 9]
                 continue
             end
             str_tree = string_tree(tree, options)
-            @test str_tree == String(strip(str_tree, [' ', '\n', '"', ',', '.', '[', ']']))
-            expr_tree = parse_expr(T, str_tree, options)
+            @assert str_tree ==
+                String(strip(str_tree, [' ', '\n', '"', ',', '.', '[', ']']))
+            expr_tree = parse_expression(
+                Meta.parse(str_tree);
+                operators=options.operators,
+                node_type=options.node_type,
+                expression_type=options.expression_type,
+                variable_names=["x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"][1:nvar],
+            )
             expr_output = expr_tree(data, options.operators)
-            @test isapprox(expr_output, output)
+            @assert string_tree(expr_tree) == str_tree "[$i] String representation mismatch: $(string_tree(expr_tree)) vs $str_tree for tree: $str_tree"
+            @assert isapprox(expr_output, output) "[$i] Output mismatch: $(expr_output) vs $(output) for tree: $str_tree"
         end
     end
 end

--- a/test/test_lasr_parser.jl
+++ b/test/test_lasr_parser.jl
@@ -2,16 +2,17 @@
 # These are round trip tests to ensure that the parser is working correctly.
 println("Testing LaSR expression parser")
 
-using Revise
 using Random: MersenneTwister
-using DynamicExpressions: parse_expression
 using LibraryAugmentedSymbolicRegression:
-    LaSROptions, string_tree, parse_expr, render_expr, gen_random_tree
-include("test/test_params.jl")
+    LaSROptions, string_tree, parse_expr, gen_random_tree
+include("test_params.jl")
 
 @inline safepow(x, y) = sign(x) * abs(x)^y
-options = Options(;
-    default_params..., binary_operators=[-, +, *, safepow], unary_operators=[sin, cos, exp]
+options = LaSROptions(;
+    default_params...,
+    binary_operators=[-, +, *, safepow],
+    unary_operators=[sin, cos, exp],
+    variable_names=Dict('x' * string(i) => ('x' * string(i)) for i in 1:9),
 )
 
 rng = MersenneTwister(314159)
@@ -27,18 +28,11 @@ for depth in [5, 9]
                 continue
             end
             str_tree = string_tree(tree, options)
-            @assert str_tree ==
-                String(strip(str_tree, [' ', '\n', '"', ',', '.', '[', ']']))
-            expr_tree = parse_expression(
-                Meta.parse(str_tree);
-                operators=options.operators,
-                node_type=options.node_type,
-                expression_type=options.expression_type,
-                variable_names=["x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"][1:nvar],
-            )
+            @test str_tree == String(strip(str_tree, [' ', '\n', '"', ',', '.', '[', ']']))
+            expr_tree = parse_expr(T, str_tree, options)
             expr_output = expr_tree(data, options.operators)
-            @assert string_tree(expr_tree) == str_tree "[$i] String representation mismatch: $(string_tree(expr_tree)) vs $str_tree for tree: $str_tree"
-            @assert isapprox(expr_output, output) "[$i] Output mismatch: $(expr_output) vs $(output) for tree: $str_tree"
+            @test string_tree(expr_tree) == str_tree # "[$i] String representation mismatch: $(string_tree(expr_tree)) vs $str_tree for tree: $str_tree"
+            @test isapprox(expr_output, output) # "[$i] Output mismatch: $(expr_output) vs $(output) for tree: $str_tree"
         end
     end
 end

--- a/test/test_lasr_parser_hard.jl
+++ b/test/test_lasr_parser_hard.jl
@@ -19,8 +19,9 @@ include("test_params.jl")
 
 options = LaSROptions(;
     default_params...,
-    binary_operators=[addf, mulf, divf],
+    binary_operators=[+, addf, mulf, divf],
     unary_operators=[sinf, cosf, expf, safelog, sqr, cube],
+    variable_names=Dict('x' * string(i) => ('x' * string(i)) for i in 1:9),
 )
 rng = MersenneTwister(314159)
 
@@ -37,7 +38,7 @@ This function takes as argument a well formatted string such as
 function fuzz_string(str::String)
     fuzzers = [
         s -> "y = " * s,  # Introduce a left hand side
-        s -> replace(s, r"\s" => " "),  # Add random spaces
+        s -> replace(s, r"\s" => " "),  # Add spaces
         s -> replace(s, r"sin" => "Sin"),  # capitalization
         s -> replace(s, r"cos" => "Cos"),  # capitalization
         s -> replace(s, r"exp" => "Exp"),  # capitalization


### PR DESCRIPTION
This PR bumps up LaSR to use SR.jl 2.0, along with minor changes.

Changes not planned (in this PR):
 - Update to new SR.jl API.
 - Deep rewriting to support provenance frameworks.