### PR TITLE
Remove forced lowercasing

### DIFF
--- a/src/Parse.jl
+++ b/src/Parse.jl
@@ -87,8 +87,6 @@ function _normalize_expr_string(s::AbstractString)
     # Replace standalone C or (C) with 1.0 or (1.0)
     s = replace(s, r"(?<!\w)C(?!\w)" => "1.0")
     s = replace(s, r"(?<!\w)\(C\)(?!\w)" => "(1.0)")
-    # TODO: Right now, making all variables lowercase. This might not always be desired.
-    s = lowercase(s)
     s = replace(s, r"\*\*" => "^")
     strip(s)
 end


### PR DESCRIPTION
Issue #63 finds that forcing parsed variables to lowercase causes collisions with restricted variables. This PR hopes to address further issues with parsing.